### PR TITLE
Modify button to play letter sound

### DIFF
--- a/workspace/son-des-lettres/src/components/SoundCard.tsx
+++ b/workspace/son-des-lettres/src/components/SoundCard.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import type { TSound } from '../data/sounds';
-import { speak, speakSequence } from '../utils/speech';
+import { speak } from '../utils/speech';
 
 function escapeRegExp(input: string): string {
   return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -32,9 +32,7 @@ function HighlightedWord({ word, patterns, color }: { word: string; patterns: st
 
 export function SoundCard({ sound, voice }: { sound: TSound; voice: SpeechSynthesisVoice | null }) {
   const handleSpeakSound = () => {
-    const intro = `Le son ${sound.label}.`;
-    const examples = sound.examples.map((e) => e.word);
-    speakSequence([intro, ...examples], voice);
+    speak(sound.label, voice);
   };
 
   return (


### PR DESCRIPTION
Change the 'Écouter' button to play only the letter sound instead of a sequence of examples.

---
<a href="https://cursor.com/background-agent?bcId=bc-37d06f4a-a649-4ec6-aacc-56e70040a1a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-37d06f4a-a649-4ec6-aacc-56e70040a1a5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

